### PR TITLE
S3 #114 Ammo

### DIFF
--- a/djGame/Assets/Resources/Ammo.prefab
+++ b/djGame/Assets/Resources/Ammo.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &127400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 432076}
+  - 212: {fileID: 21236346}
+  - 61: {fileID: 6152094}
+  m_Layer: 0
+  m_Name: Ammo
+  m_TagString: Ammo
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &432076
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 127400}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.18, y: -0.17481662, z: -2.13}
+  m_LocalScale: {x: 4, y: 4, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!61 &6152094
+BoxCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 127400}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Size: {x: 0.16, y: 0.16}
+--- !u!212 &21236346
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 127400}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 0
+  m_ReflectionProbeUsage: 0
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1309251023
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 0.9882353, g: 1, b: 0.14705884, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 127400}
+  m_IsPrefabParent: 1

--- a/djGame/Assets/Resources/Ammo.prefab.meta
+++ b/djGame/Assets/Resources/Ammo.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15433bbe941b14deab789a17e9b1b17f
+timeCreated: 1469113635
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/djGame/Assets/Resources/Bullet.prefab
+++ b/djGame/Assets/Resources/Bullet.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &133032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 463264}
+  - 212: {fileID: 21290720}
+  - 61: {fileID: 6116720}
+  - 114: {fileID: 11409546}
+  m_Layer: 0
+  m_Name: Bullet
+  m_TagString: Bullet
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &463264
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 133032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.632803, y: -0.43, z: -2.1298828}
+  m_LocalScale: {x: 0.2, y: 0.1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!61 &6116720
+BoxCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 133032}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Size: {x: 1.8, y: 1.08}
+--- !u!114 &11409546
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 133032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 644ec5bdc4b1744c880f98b28320d8ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &21290720
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 133032}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 0
+  m_ReflectionProbeUsage: 0
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1309251023
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 1cbe3cc5aade4448d98aa793eee8f99d, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 133032}
+  m_IsPrefabParent: 1

--- a/djGame/Assets/Resources/Bullet.prefab.meta
+++ b/djGame/Assets/Resources/Bullet.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3deb0dfb23b2641d583594e32a220ce5
+timeCreated: 1469118788
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/djGame/Assets/scenes/Master Scene.unity
+++ b/djGame/Assets/scenes/Master Scene.unity
@@ -214,6 +214,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 919624584}
   - {fileID: 1586215434}
   - {fileID: 2136211355}
   - {fileID: 924018214}
@@ -457,7 +458,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 150709540}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 91.399994, y: -63}
@@ -592,6 +593,94 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 704109381}
+--- !u!1 &919624583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 919624584}
+  - 222: {fileID: 919624586}
+  - 114: {fileID: 919624585}
+  - 114: {fileID: 919624587}
+  m_Layer: 5
+  m_Name: Ammo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &919624584
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 919624583}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 150709540}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 91.399994, y: -81.41}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &919624585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 919624583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Ammo:
+
+'
+--- !u!222 &919624586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 919624583}
+--- !u!114 &919624587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 919624583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 049505e0534e54028a772bec57d8507b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &924018213
 GameObject:
   m_ObjectHideFlags: 0
@@ -622,7 +711,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 150709540}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 140.02002, y: -25.200012}
@@ -860,6 +949,7 @@ MonoBehaviour:
   pause: {fileID: 2065352957}
   scoreObject: {fileID: 631870885}
   Health: {fileID: 924018213}
+  AmmoController: {fileID: 919624583}
 --- !u!50 &1000382898
 Rigidbody2D:
   serializedVersion: 2
@@ -1063,7 +1153,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 150709540}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 92.100006, y: -26.799988}
@@ -1207,7 +1297,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 150709540}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 140.02002, y: -25.200012}
@@ -1277,7 +1367,7 @@ RectTransform:
   m_Children:
   - {fileID: 2065352958}
   m_Father: {fileID: 150709540}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -44.369995, y: 44}
@@ -1397,7 +1487,7 @@ RectTransform:
   - {fileID: 534035931}
   - {fileID: 1569871919}
   m_Father: {fileID: 150709540}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 261.63, y: -202}
@@ -1618,7 +1708,7 @@ Transform:
   - {fileID: 1138850802}
   - {fileID: 1681579779}
   m_Father: {fileID: 150709540}
-  m_RootOrder: 7
+  m_RootOrder: 8
 --- !u!1 &2065352957
 GameObject:
   m_ObjectHideFlags: 0
@@ -1692,7 +1782,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 150709540}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 140.02002, y: -25.200012}

--- a/djGame/Assets/scripts/AmmoController.cs
+++ b/djGame/Assets/scripts/AmmoController.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class AmmoController : MonoBehaviour {
+
+	private int ammoCount = 5;
+
+	public void IncreaseAmmoCount(int amount){
+		ammoCount += amount;
+	}
+
+	public void DecreaseAmmoCount(int amount){
+		ammoCount -= amount;
+	}
+
+	void Update(){
+		UpdateText ();
+	}
+
+	void UpdateText(){
+		GetComponent<UnityEngine.UI.Text> ().text = "Ammo: " + ammoCount;
+	}
+
+	public bool Fireable(){
+		if (ammoCount > 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+}

--- a/djGame/Assets/scripts/AmmoController.cs.meta
+++ b/djGame/Assets/scripts/AmmoController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 049505e0534e54028a772bec57d8507b
+timeCreated: 1469112791
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/djGame/Assets/scripts/Bullet.cs
+++ b/djGame/Assets/scripts/Bullet.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class Bullet : MonoBehaviour {
+
+	private float velocity = 16;
+	private float spawnTime;
+	private float lifeSpan = 3;
+
+	void Start(){
+		spawnTime = Time.time;
+		gameObject.name = "Bullet";
+	}
+
+	void Update () {
+		transform.Translate(new Vector3(velocity * Time.deltaTime, 0, 0));
+
+		if (Time.time - spawnTime > lifeSpan) {
+			Destroy (gameObject);
+		}
+
+	}
+
+	public void TravelDirection(Vector2 direction){
+		if (direction.x < 0) {
+			velocity = velocity * -1;
+		}
+	}
+
+}

--- a/djGame/Assets/scripts/Bullet.cs.meta
+++ b/djGame/Assets/scripts/Bullet.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 644ec5bdc4b1744c880f98b28320d8ac
+timeCreated: 1469118344
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/djGame/Assets/scripts/Chunk.cs
+++ b/djGame/Assets/scripts/Chunk.cs
@@ -43,19 +43,50 @@ public class Chunk : MonoBehaviour
 
 		SpawnScenery ("Bones", .02f, -.5f, new string[]{"bones_a", "cowskull_a"}); 
 
-
-
 		SpawnScenery ("Sign", .01f, -0.12f); 
 
-		//Instantiate (Resources.Load ("Desert Ground") as GameObject, new Vector3 (0, 0, 0), Quaternion.Euler (0, 0, 0));
+		SpawnPickup ("Ammo", 0.02f, -0.42f);
 
-//		gameObject.GetComponent<SpriteRenderer>().sortingOrder
-
-        //If you want to spawn something rare, than do this.
-        //SpawnPrefab("Rare_Thing", .02f, 0, chunkWidth);
-        //It will spawn at a 2% chance and disregards proximity.    
 
     }
+
+	private void SpawnPickup(string prefab, float spawnChance, float spawnHeight){
+		spawnChance = Mathf.Clamp01 (spawnChance);
+
+		//Farthest left point in chunk.
+		Vector2 spawnLocation = new Vector2 (transform.position.x - chunkWidth / 2, spawnHeight);
+		Vector2 startLocation = spawnLocation;
+
+		//Iterates through chunk left to right.
+		for (int i = 0; i < chunkWidth; i++) {
+			
+			//Chance to spawn.
+			if (Random.value < spawnChance) {
+
+				bool overlappingObstacle = false;
+				for (int j = 0; j < transform.childCount; j++) {
+					
+					if (spawnLocation.x == transform.GetChild (j).position.x
+					    &&
+						transform.GetChild (j).tag == "collision_obstacle") {
+//						print ("Overlap between me: " + spawnLocation.x + " and this:" + transform.GetChild (j).tag);
+						overlappingObstacle = true;
+					}
+				}
+
+				if (!overlappingObstacle) {
+
+					GameObject spawnedPickup = Instantiate (Resources.Load (prefab),
+						                           new Vector2 (spawnLocation.x, spawnLocation.y),
+						                           Quaternion.Euler (new Vector3 (0, 0, 0))) as GameObject;
+
+					spawnedPickup.transform.parent = transform;
+					spawnedPickup.name = prefab;
+				}
+			}
+			spawnLocation.x += 1;
+		}
+	}
 
 	private void SpawnScenery(string prefab, float spawnChance, float spawnHeight, string[] alternateSprites = null){
 		spawnChance = Mathf.Clamp01 (spawnChance);
@@ -68,16 +99,33 @@ public class Chunk : MonoBehaviour
 		for (int i = 0; i < chunkWidth; i++) {
 			//Chance to spawn.
 			if (Random.value < spawnChance) {
-				GameObject spawnedScenery = Instantiate (Resources.Load (prefab),
-					new Vector2 (spawnLocation.x + i, spawnLocation.y),
-					Quaternion.Euler(new Vector3(0,0,0))) as GameObject;
+
+				bool overlappingObstacle = false;
+				for (int j = 0; j < transform.childCount; j++) {
+
+					if (spawnLocation.x == transform.GetChild (j).position.x
+						&&
+						(transform.GetChild (j).tag == "Scenery" || transform.GetChild (j).tag == "collision_obstacle")) {
+
+//						print ("Overlap between" + (Resources.Load (prefab) as GameObject).tag + " and " + transform.GetChild (j).tag);
+
+						overlappingObstacle = true;
+					}
+				}
+
+				if (!overlappingObstacle) {
+					GameObject spawnedScenery = Instantiate (Resources.Load (prefab),
+						                           new Vector2 (spawnLocation.x, spawnLocation.y),
+						                           Quaternion.Euler (new Vector3 (0, 0, 0))) as GameObject;
 				
-				spawnedScenery.transform.parent = transform;
-				spawnedScenery.name = prefab;
-				if (alternateSprites != null) {
-					spawnedScenery.GetComponent<SpriteRenderer> ().sprite = Resources.Load<Sprite> (alternateSprites [Random.Range (0, alternateSprites.Length)]);
-				} 
+					spawnedScenery.transform.parent = transform;
+					spawnedScenery.name = prefab;
+					if (alternateSprites != null) {
+						spawnedScenery.GetComponent<SpriteRenderer> ().sprite = Resources.Load<Sprite> (alternateSprites [Random.Range (0, alternateSprites.Length)]);
+					} 
+				}
 			}
+			spawnLocation.x++;
 		}
 	}
 

--- a/djGame/Assets/scripts/ChunkController.cs
+++ b/djGame/Assets/scripts/ChunkController.cs
@@ -51,7 +51,12 @@ public class ChunkController : MonoBehaviour
 
 		if (screenWidth > chunkWidth) {
 			//+5 to give th 5 units of travel time to load the next chunk.
-			chunkWidth = Mathf.CeilToInt (screenWidth+4);
+			chunkWidth = Mathf.CeilToInt (screenWidth+5);
+
+			//Must be even to prevent gap between chunks.
+			if (chunkWidth % 2 == 1) {
+				chunkWidth++;
+			}
 		}
 
 	}

--- a/djGame/Assets/scripts/ChunkController.cs
+++ b/djGame/Assets/scripts/ChunkController.cs
@@ -12,14 +12,17 @@ public class ChunkController : MonoBehaviour
     private static Vector2 _initialCameraPosition;
     private Vector2 _currentCameraPosition;
     private static int _chunkCount;
+
     public bool debug = true;
-    public float chunkMoveSpeed = 4f;
+    
+	public float chunkMoveSpeed = 4f;
+
 	private int chunkWidth = 10;
 
-    public bool _collision = false; 
-    private float _impactSpeedDecay = 0.1f;
-    private float _impactSpeedReduction = 0.1f;
-    public float _knockDownTime = 1f;
+    
+    
+    
+    
 
     void Start()
     {
@@ -126,43 +129,11 @@ public class ChunkController : MonoBehaviour
 
     void ChunkMovement()
     {
-        if (!_collision)
-        {
-            LeftMovement();
-        }
-        else
-        {
-            ChunkRebound();  
-        }
+        
+        LeftMovement();
+        
     }
-
-    public void ResumeMovement()
-    {
-        _collision = false;
-        _impactSpeedReduction = _impactSpeedDecay;
-    }
-
-    private void ChunkRebound()
-    {
-        for (int i = 0; i < gameObject.transform.childCount; i++)
-        {
-            gameObject.transform.GetChild(i).transform.Translate(new Vector2(1 * (chunkMoveSpeed - _impactSpeedReduction) * Time.deltaTime, 0));
-        }
-
-        if (_impactSpeedReduction < chunkMoveSpeed)
-        {
-            _impactSpeedReduction += _impactSpeedDecay;
-        }
-        else
-        {
-            _impactSpeedReduction = chunkMoveSpeed;
-        }
-    }
-
-    public void PlayerCollision()
-    {
-        _collision = true;
-    }
+		
 
     private void LeftMovement()
     {

--- a/djGame/Assets/scripts/PlayerController.cs
+++ b/djGame/Assets/scripts/PlayerController.cs
@@ -36,6 +36,9 @@ public class PlayerController : MonoBehaviour
 	public GameObject Health;
 	private HealthController healthController;
 
+	public GameObject AmmoController;
+	private AmmoController ammoController;
+
 	private bool touched = false;
 
 
@@ -48,47 +51,92 @@ public class PlayerController : MonoBehaviour
 		score.SetScoreRate (10);
 
 		healthController = Health.GetComponent<HealthController> ();
+		ammoController = AmmoController.GetComponent<AmmoController> ();
 	}
 
 	void Update ()
 	{
-		JumpControl ();
+		Controls ();
 
 		if (collision) {
 			KnockDown ();
 		}
 
 	}
-
-	void JumpControl ()
+		
+	void Controls ()
 	{
+		Jumping ();
+
+		Shooting ();
+	
+	}
+
+	void Jumping(){
+
+		//PC
+
 		//Checks to see if player is in contact with ground directly beneath them.
 		isGrounded = Physics2D.OverlapCircle (groundPoint.position, groundPointRadius, groundMask);
 
+		//Check if game is paused.
 		paused = pause.GetComponent<Pause> ().paused;
 
 		//Jumping controls.
-		if (Input.GetKeyDown (KeyCode.Space) && isGrounded && !paused) {
+		if (Input.GetKeyDown (KeyCode.W) && isGrounded && !paused) {
 			rb2D.AddForce (new Vector2 (0, jumpHeight));
 
 		}
 
+		//Touch Device
 		foreach (Touch touch in Input.touches) {
 
 			if (touch.phase != TouchPhase.Ended && touch.phase != TouchPhase.Canceled) {
-				if (isGrounded && !paused && !touched && !EventSystem.current.IsPointerOverGameObject(touch.fingerId)) {
-					rb2D.AddForce (new Vector2 (0, jumpHeight));
-					touched = true;
-				}
-				if (EventSystem.current.IsPointerOverGameObject (touch.fingerId)) {
-					print ("UI");
+				if (touch.position.x > Screen.width / 2) {
+					if (isGrounded && !paused && !touched && !EventSystem.current.IsPointerOverGameObject (touch.fingerId)) {
+						rb2D.AddForce (new Vector2 (0, jumpHeight));
+						//So that jumping can only be triggered once per touch and release.
+						touched = true;
+					}
 				}
 			}
 		}
+
 		if (Input.touches.Length == 0) {
 			touched = false;
 		}
 
+
+	}
+
+	void Shooting(){
+		//PC
+		if (Input.GetKeyDown (KeyCode.Space)) {
+			Shoot ();
+		}
+
+		//Touch Device
+		foreach (Touch touch in Input.touches) {
+			if (touch.phase != TouchPhase.Ended && touch.phase != TouchPhase.Canceled) {
+				if (touch.position.x < Screen.width / 2) {
+					Shoot ();
+				}
+			}
+		}
+	}
+
+	void Shoot(){
+		if (ammoController.Fireable()) {
+			
+			ammoController.DecreaseAmmoCount (1);
+			GameObject bullet = Instantiate(Resources.Load("Bullet"), new Vector3(transform.position.x + .75f,
+				transform.position.y + .125f , 0),
+				Quaternion.Euler(0,0,0)) as GameObject;
+
+			bullet.GetComponent<Bullet>().TravelDirection (new Vector2 (1, 0));
+
+			
+		}
 	}
 
 	void OnTriggerEnter2D (Collider2D other)
@@ -100,8 +148,13 @@ public class PlayerController : MonoBehaviour
 			score.PauseScore ();
 			healthController.LoseHealth (34);
 			GameObject.Destroy (other.gameObject);
-
 		}
+
+		if (other.gameObject.tag == "Ammo") {
+			ammoController.IncreaseAmmoCount (5);
+			Destroy (other.gameObject);
+		}
+
 	}
 
 	void KnockDown ()

--- a/djGame/ProjectSettings/TagManager.asset
+++ b/djGame/ProjectSettings/TagManager.asset
@@ -7,6 +7,8 @@ TagManager:
   - collision_obstacle
   - Ground
   - Scenery
+  - Ammo
+  - Bullet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Changed controls. For PC jumping is now ‘W’ while shooting is spacebar.
On a touch device jumping is tapping on the right side of the screen
while shooting is tapping on the left side. The reason why shooting is
on the left side is because I plan to have enemies slowly chase the
player from the left side of the screen. Enemies can trip on ground
obstacles just like the player, or jump over (chance roll?), but can
also be shot.

also..

Implemented Invisibility after hitting an object with the
collision_obstacle tag.
